### PR TITLE
Checking the endpoint.url

### DIFF
--- a/imports/discourse-api/discourse-connector.js
+++ b/imports/discourse-api/discourse-connector.js
@@ -101,8 +101,13 @@ class DiscourseContext {
       return endpoint.fetch(args, this);
     }
 
-    return this.urlDataLoader.load(this.apiRoot + endpoint.url(args))
-      .then(endpoint.map || identity);
+    if (typeof endpoint.url === 'function') {
+      return this.urlDataLoader.load(this.apiRoot +  endpoint.url(args))
+        .then(endpoint.map || identity);
+    } else {
+      return this.urlDataLoader.load(this.apiRoot +  endpoint.url)
+        .then(endpoint.map || identity);
+    }
   }
 
   get(url) {


### PR DESCRIPTION
Hey @stubailo,

When performing a simple query  the `endpoint.url` is just a string, so it returns an error when we try to use it as a function and pass in the non-existent args.  

Not sure if `typeof` is the best way to do it, or to just simply check if there are any args.

To replicate the problem go to graphiQL and run:

```
{
  allPosts {
    id
  }
}
```
